### PR TITLE
Fix typo in webpack URL loader configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ module.exports = {
       loaders: ['style', CSSLoader, 'sass']
     }, {
       test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-      loader: "url-loader?limit=10000&minetype=application/font-woff"
+      loader: "url-loader?limit=10000&mimetype=application/font-woff"
     }, {
       test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
       loader: "file-loader"


### PR DESCRIPTION
### Related issues: <!-- If applicable: reference any related issues. E.g: #4515   --> 
### Changes
<!-- Describe and explain the changes you made. --> 
<!-- If applicable: add some screenshots --> 


### Testing guide
<!-- Describe the steps to test the changes made --> 


### Checklist
- [ ] I ran the tests of Reapop with `npm run test:all` 
- [ ] I updated the README or API documentation (if applicable)
- [ ] I updated the demo (if applicable)
- [ ] I verified my changes on all browsers listed below:
  - [ ] Chrome
  - [ ] Safari
  - [ ] Firefox
  - [ ] IE 10+
  - [ ] Edge
  - [ ] Opera

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/reapop-theme-bootstrap/17)
<!-- Reviewable:end -->
